### PR TITLE
Add basic VAD to reduce noise

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A FreeSWITCH module that streams L16 audio from a channel to a websocket endpoint. If websocket sends back responses (eg. JSON) it can be effectively used with ASR engines such as IBM Watson etc., or any other purpose you find applicable.
 
+This module now includes a lightweight voice activity detector that suppresses low-energy noise by replacing silent frames with zeroed audio. The continuous stream required by recognizers such as Dialogflow is preserved while reducing unnecessary background noise.
+
 ### Update (22/2/2025)
 
 #### :rocket: **Introducing Bi-Directional Streaming with automatic playback**

--- a/mod_audio_stream.h
+++ b/mod_audio_stream.h
@@ -31,6 +31,7 @@ struct private_data {
     int close_requested:1;
     char initialMetadata[8192];
     switch_buffer_t *sbuffer;
+    double vad_noise_level;
     int rtp_packets;
 };
 


### PR DESCRIPTION
## Summary
- track noise floor per session and expose it in private data
- zero out low-energy frames using a simple voice activity detector
- document new VAD behavior in README

## Testing
- `make` *(fails: The source directory "/home/andrea-batazzi/dev/lab/2025/mod_audio_stream" does not exist)*
- `cmake ..` *(fails: CMakeCache.txt directory mismatch)*

------
https://chatgpt.com/codex/tasks/task_b_689b45d3192483308f7b0b34c37427b0